### PR TITLE
Blog on 2025 Meet-ups

### DIFF
--- a/articles/meetups_2025
+++ b/articles/meetups_2025
@@ -19,7 +19,51 @@ At the Durham HPC Days, which traditionally happen in Durham in the week preceed
 and the session on Benchmarking, which ran in parallel, we still had a good group of people in the room. Some of them were new to the HPC RSE SIG and heard for the first time about what we do and how we are
 related to the RSE Society and the HPC SIG.
 
-After a short introduction, we ran world-cafe-style discussion around the topics of career and training, technology and software, and community.
+After a short introduction, we ran world-cafe-style discussion around the topics of career and training, technology and software, and community. For each of these topics we discussed positive and 
+negative aspects, as well as ideas we had.
+
+### Technology and Software
+
+- Positive: Some random techy bits: There is great local support for Tier 2, new Spack version is coming out soon. Many of us are excited about the current situation with lots of change, and new 
+problems to tackle. There are impressive technologies out there, and the combination of HPC and AI has huge opportunities. AI can also be useful for coding (if you check and correct/adapt)
+- Negative: Again, Tier 2s: support and funding is disappearing. :( Procurement is slow, especially for GPUs. There is a lot of badly written code out there, and people start to rely too much
+on LLMs. There is a fear that AI tools will change our jobs and careers, and not everyone likes that (or will be better off). And generally, the amount of "stuff" (AI, cloud, HPC,...) out there can be 
+overwhelming.
+- Ideas:
+  - Literacy for users on sustainable use of software.
+  - Use synergy between HPC and AI, foster collaboration. Not everyone needs to do AI - but it also should not be a case of "us vs. them". We should join teams, where appropriate, and become a "we".
+  - There are mixed experiences with using AI for coding - good for explaining code.
+  - Improve interpretability for compiled languages.
+
+### Training and Careers
+- Positive: Places like the MetOffice have proper career progression without the requirement to publish and with a proper skills framework, and even level 6 apprenticeships - 
+this would make a great case study. The RSE movement has been quite successful over the past >10 years. The relationship with IT can work well, and many RSE teams at universities do "sales pitches"
+to research departments, and/or use training to get a "foot in the door". People also get writting into grants (or even become Co-I), and mobility between universities/groups is reasonably good.
+- Negative: The university model with its academic tenure track and values does not fit well for most RSEs - what would be the "professor level" for an RSE? There is still a lot of push-back when
+RSEs want to lead on grants (often they are not included in the grant writing process), and at many universities, RSEs are pushed into professional services - which, again, is often not a good fit. 
+For career progression, in most places, you have to apply for a new position.
+- Ideas:
+  - Show the benefits of a close link between RSEs and scientists.
+  - Co-locate expertise - not RSEs and equipment.
+  - Embed RSEs into research groups, while maintaining central "best practice" links and links to IT.
+  - Formalise IT/Research straddle/leadership model.
+  - Flexible roles which don't require grants and publication. => more opportunities
+  - Advertise the [UK Institute for Technical Skills and Strategy (ITSS)](https://itss.org.uk/) - people don't know about it!
+
+### Community
+
+- Positive: Slack and other online platforms are great for connecting people, and have a low barrier (not as scary as in-person), while conference and in-person events are great for networking. 
+There are amazing skills in the community, and especially the RSE community is organised really well.
+- Negative: There are still local groups which are not well connected to the wider RSE community. It can often be difficult to find the time alongside the day job. Online communication platforms 
+can be overwhelming, and not all info is trickling down to the right people. There is still a lack of visibility of RSEs and their specialisms outside their community and traditional science, and 
+knowledge exchange beyond Slack is needed. Also, outcomes of RSE projects and capabilities of RSEs need to be advertised better.
+- Ideas: 
+  - More social online networking outside of conferences would be useful for those who are socially insecure. 
+  - Active outreach to non-traditional communities.
+  - Accepting RSEs as PIs - cultural change.
+  - Breaking stereotypes.
+  - Sales training/outreach skills. => promote what RSE means, but also outcomes and work done
+
 
 ## HPC RSE Birds-of-a-Feather RSECon25
 

--- a/articles/meetups_2025
+++ b/articles/meetups_2025
@@ -1,0 +1,27 @@
+# HPC RSE SIG Meet-ups 2025
+
+## Online Meet-up May 19
+
+This online meet-up was the first meet-up of the community after officially going through the process of becoming a Special Interest Group under the Society of Research Software Engineering. 
+
+We had a range of interesting talks from the HPC RSE community:
+
+- Scaling the Stars: Optimizing MPI communication on GPUs in the PROMPI stellar dynamics code; Miren Radia, Research Computing Services, University of Cambridge
+- Custom Acceleration Frameworks: the good, the bad, and the ugly; Ilektra Chritidi, Mashy Green, UCL
+- FRIDGE: A shared responsibility model for deploying Trusted Research Environments on High Performance Compute systems; Martin O’Reilly, The Alan Turing Institute
+- Connecting the DRI community through CAKE; Nick Brown, EPCC, University of Edinburgh
+
+These were followed by a group discussion on what the HPC RSE community would like to see from the SIG going forward.
+
+## In-person Meet-up at Durham HPC Days, June 5
+
+At the Durham HPC Days, which traditionally happen in Durham in the week preceeding ISC, we had a session blocked to meet-up in person. Although a lot of HPC RSEs were torn between this session
+and the session on Benchmarking, which ran in parallel, we still had a good group of people in the room. Some of them were new to the HPC RSE SIG and heard for the first time about what we do and how we are
+related to the RSE Society and the HPC SIG.
+
+After a short introduction, we ran world-cafe-style discussion around the topics of career and training, technology and software, and community.
+
+## HPC RSE Birds-of-a-Feather RSECon25
+
+[HPCRSE@RSECon25: 4th annual meeting of the HPC RSE community](https://virtual.oxfordabstracts.com/event/75166/submission/66)
+

--- a/articles/meetups_2025.md
+++ b/articles/meetups_2025.md
@@ -7,11 +7,15 @@ This online meet-up was the first meet-up of the community after officially goin
 We had a range of interesting talks from the HPC RSE community:
 
 ### Scaling the Stars: Optimizing MPI communication on GPUs in the PROMPI stellar dynamics code; Miren Radia, Research Computing Services, University of Cambridge
+[presentation](https://drive.google.com/file/d/1XJG-h6JUjAa7GXg2J8KbZm_7p2HRV4Jm/view?usp=drive_link)
+
 ### Custom Acceleration Frameworks: the good, the bad, and the ugly; Ilektra Chritidi, Mashy Green, UCL
+[presentation](https://docs.google.com/presentation/d/11Gf0vOFh4GKP9rFxEjzTe9TM08WPHF4E/edit?usp=drive_link&ouid=117268427484378159786&rtpof=true&sd=true)
 In this talk, Mashy green talked about their experiences working with custom abstractions on accelerator offloading. As a HPC RSE, it is good to be aware of the pros
 and cons of different software options for offloading, from native languages like CUDA and HIP to third party libraries such as Kokkos and Raja. Developing and maintaing
 your own custom framework within a codebase is a major effort but it can pay off if you really need to fine tune the performance and abstraction balance for a specific codebase.
 ### FRIDGE: A shared responsibility model for deploying Trusted Research Environments on High Performance Compute systems; Martin O’Reilly, The Alan Turing Institute
+[presentation](https://drive.google.com/file/d/1Vf8W8923u_0tHhUE6gqzFuGgWnLgSyS8/view?usp=drive_link)
 ### Connecting the DRI community through CAKE; Nick Brown, EPCC, University of Edinburgh
 
 These were followed by a group discussion on what the HPC RSE community would like to see from the SIG going forward.

--- a/blog.md
+++ b/blog.md
@@ -2,6 +2,8 @@
 
 ## 2025
 
+[HPC RSE SIG Meet-ups in 2025](articles/meetups_2025.html)
+
 ## 2024
 [HPCRSE@RSECon24: 3rd annual meeting of the HPC RSE community](https://society-rse.org/hpcrsersecon24-3rd-annual-meeting-of-the-hpc-rse-community/)
 [HPC RSE March 2024 Online Meetup](https://www.archer2.ac.uk/news/2024/03/28/hpc-rse-meetup.html)


### PR DESCRIPTION
This PR creates a blog posts on the meet-ups in 2025. It starts with the online meet-up in May and the in-person meet-up at the Durham HPC Days. For the RSECon BoF there is a link to the session as a placeholder